### PR TITLE
Feature: Add in memory SQLite database

### DIFF
--- a/Api.Battleships/Api.Battleships.csproj
+++ b/Api.Battleships/Api.Battleships.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <Folder Include="Services\" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
   </ItemGroup>
 

--- a/Api.Battleships/Database/BattleshipsContext.cs
+++ b/Api.Battleships/Database/BattleshipsContext.cs
@@ -1,0 +1,27 @@
+﻿using Api.Battleships.Database.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Battleships.Database
+{
+	public class BattleshipsContext : DbContext
+	{
+		public virtual DbSet<Game> Games { get; set; }
+		public virtual DbSet<Ship> Ships { get; set; }
+		public virtual DbSet<ShipCell> ShipCells { get; set; }
+		public virtual DbSet<Torpedo> Torpedoes { get; set; }
+
+		public BattleshipsContext(DbContextOptions<BattleshipsContext> options)
+			: base(options)
+		{
+		}
+
+		protected override void OnModelCreating(ModelBuilder modelBuilder)
+		{
+			modelBuilder
+				.MapGame()
+				.MapShip()
+				.MapShipCell()
+				.MapTorpedo();
+		}
+	}
+}

--- a/Api.Battleships/Database/InMemoryBattleshipsContextFactory.cs
+++ b/Api.Battleships/Database/InMemoryBattleshipsContextFactory.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Battleships.Database
+{
+	public class InMemoryBattleshipsContextFactory : IDbContextFactory<BattleshipsContext>
+	{
+		private readonly InMemoryDbConnection _connection;
+		private readonly ILoggerFactory _loggerFactory;
+
+		public InMemoryBattleshipsContextFactory(InMemoryDbConnection connection, ILoggerFactory loggerFactory)
+		{
+			_connection = connection;
+			_loggerFactory = loggerFactory;
+		}
+
+		public BattleshipsContext CreateDbContext()
+		{
+			var optionsBuilder = new DbContextOptionsBuilder<BattleshipsContext>();
+			optionsBuilder
+				.UseSqlite(_connection.DbConnection)
+				.UseLoggerFactory(_loggerFactory);
+
+			return new BattleshipsContext(optionsBuilder.Options);
+		}
+	}
+}

--- a/Api.Battleships/Database/InMemoryDbConnection.cs
+++ b/Api.Battleships/Database/InMemoryDbConnection.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+
+namespace Api.Battleships.Database
+{
+	public class InMemoryDbConnection : IDisposable
+	{
+		private readonly object _connectionLock = new object();
+
+		private DbConnection _connection;
+
+		public DbConnection DbConnection => _connection ?? CreateInMemoryDatabase();
+
+		private DbConnection CreateInMemoryDatabase()
+		{
+			lock (_connectionLock)
+			{
+				if (_connection != null)
+					return _connection;
+
+				// Note: Disposing this connection removes the database from memory.
+				_connection = new SqliteConnection("Data Source=:memory:");
+				_connection.Open();
+
+				return _connection;
+			}
+		}
+
+		public void Dispose()
+		{
+			lock (_connectionLock)
+			{
+				_connection?.Dispose();
+				_connection = null;
+			}
+		}
+	}
+}

--- a/Api.Battleships/Database/Models/Game.cs
+++ b/Api.Battleships/Database/Models/Game.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Battleships.Database.Models
+{
+	public class Game
+	{
+		public int Id { get; set; }
+
+		public virtual ICollection<Ship> Ships { get; set; } = new HashSet<Ship>();
+		public virtual ICollection<Torpedo> Torpedoes { get; set; } = new HashSet<Torpedo>();
+	}
+
+	internal static class GameMapping
+	{
+		internal static ModelBuilder MapGame(this ModelBuilder modelBuilder)
+		{
+			return modelBuilder.Entity<Game>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+
+				entity.ToTable("game");
+
+				entity.Property(e => e.Id)
+					.HasColumnName("id");
+			});
+		}
+	}
+}

--- a/Api.Battleships/Database/Models/Ship.cs
+++ b/Api.Battleships/Database/Models/Ship.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Battleships.Database.Models
+{
+	public class Ship
+	{
+		public int Id { get; set; }
+		public int GameId { get; set; }
+
+		public virtual Game Game { get; set; }
+		public virtual ICollection<ShipCell> ShipCells { get; set; } = new HashSet<ShipCell>();
+	}
+
+	internal static class ShipMapping
+	{
+		internal static ModelBuilder MapShip(this ModelBuilder modelBuilder)
+		{
+			return modelBuilder.Entity<Ship>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+
+				entity.ToTable("ship");
+
+				entity
+					.Property(e => e.Id)
+					.HasColumnName("id");
+
+				entity.HasIndex(e => e.GameId);
+
+				entity
+					.Property(e => e.GameId)
+					.HasColumnName("gameid");
+
+				entity
+					.HasOne(s => s.Game)
+					.WithMany(g => g.Ships)
+					.HasForeignKey(s => s.GameId)
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
+			});
+		}
+	}
+}

--- a/Api.Battleships/Database/Models/ShipCell.cs
+++ b/Api.Battleships/Database/Models/ShipCell.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Api.Battleships.Database.Models
+{
+	public class ShipCell
+	{
+		public int Id { get; set; }
+		public int ShipId { get; set; }
+		public int? TorpedoId { get; set; }
+		public int Row { get; set; }
+		public int Column { get; set; }
+
+		public virtual Ship Ship { get; set; }
+		public virtual Torpedo HitByTorpedo { get; set; }
+	}
+	internal static class ShipCellMapping
+	{
+		internal static ModelBuilder MapShipCell(this ModelBuilder modelBuilder)
+		{
+			return modelBuilder.Entity<ShipCell>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+
+				entity.ToTable("shipcell");
+
+				entity
+					.Property(e => e.Id)
+					.HasColumnName("id");
+
+				entity.HasIndex(e => e.ShipId);
+				entity.HasIndex(e => e.TorpedoId);
+
+				entity
+					.Property(e => e.ShipId)
+					.HasColumnName("shipid");
+
+				entity
+					.Property(e => e.TorpedoId)
+					.HasColumnName("torpedoid")
+					.IsRequired(false);
+
+				entity
+					.Property(e => e.Row)
+					.HasColumnName("row");
+
+				entity
+					.Property(e => e.Column)
+					.HasColumnName("column");
+
+				entity
+					.HasOne(c => c.Ship)
+					.WithMany(s => s.ShipCells)
+					.HasForeignKey(c => c.ShipId)
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
+
+				entity
+					.HasOne(c => c.HitByTorpedo)
+					.WithOne(t => t.HitShip)
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired(false);
+			});
+		}
+	}
+}

--- a/Api.Battleships/Database/Models/Torpedo.cs
+++ b/Api.Battleships/Database/Models/Torpedo.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Api.Battleships.Database.Models
+{
+	public class Torpedo
+	{
+		public int Id { get; set; }
+		public int GameId { get; set; }
+		public int Row { get; set; }
+		public int Column { get; set; }
+
+		public virtual Game Game { get; set; }
+		public virtual ShipCell HitShip { get; set; }
+	}
+
+	internal static class TorpedoMapping
+	{
+		internal static ModelBuilder MapTorpedo(this ModelBuilder modelBuilder)
+		{
+			return modelBuilder.Entity<Torpedo>(entity =>
+			{
+				entity.HasKey(e => e.Id);
+
+				entity.ToTable("torpedo");
+
+				entity.HasIndex(e => new
+				{
+					e.GameId,
+					e.Row,
+					e.Column,
+				}).IsUnique();
+
+				entity
+					.Property(e => e.Id)
+					.HasColumnName("id");
+
+				entity.HasIndex(e => e.GameId);
+
+				entity
+					.Property(e => e.GameId)
+					.HasColumnName("gameid");
+
+				entity
+					.Property(e => e.Row)
+					.HasColumnName("row");
+
+				entity
+					.Property(e => e.Column)
+					.HasColumnName("column");
+
+				entity
+					.HasOne(s => s.Game)
+					.WithMany(g => g.Torpedoes)
+					.HasForeignKey(s => s.GameId)
+					.OnDelete(DeleteBehavior.Cascade)
+					.IsRequired();
+			});
+		}
+	}
+}


### PR DESCRIPTION
- Using EFCore we can have nice scaffolded in memory db's
- Added a `snigleton` `InMemoryDbConnection` that remains open while running the API, when this connection is disposed the data in the database is cleaned up.