### PR TITLE
Bug: Disable https redirection in development

### DIFF
--- a/Api.Battleships/Startup.cs
+++ b/Api.Battleships/Startup.cs
@@ -71,6 +71,10 @@ namespace Api.Battleships
 			{
 				app.UseDeveloperExceptionPage();
 			}
+			else
+            {
+				app.UseHttpsRedirection();
+			}
 
 			app.UseSwagger();
 			app.UseSwaggerUI(c =>
@@ -78,8 +82,6 @@ namespace Api.Battleships
 				c.SwaggerEndpoint("/swagger/v1/swagger.json", "Battleships API V1");
 				c.RoutePrefix = string.Empty;
 			});
-
-			app.UseHttpsRedirection();
 
 			app.UseRouting();
 


### PR DESCRIPTION
This removes a warning from logs as we're debugging the API without HTTPS